### PR TITLE
Refactored the code, added zoom support for Inpaint Sketch and Sketch, add hotkeys to reload and overlap

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,8 @@ Shortcuts:
 
 **R** - Reset Zoom.
 
+**Q** - Open/Close color panel
+
 **O** - Overlap all elements and back
 
 **Ctr-Z** - Undo last action

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,5 @@
+An extension of [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
+
 Adds the ability to zoom into Inpaint, Sketch, and Inpaint Sketch.
 
 Shortcuts:

--- a/README.MD
+++ b/README.MD
@@ -13,3 +13,7 @@ Shortcuts:
 **R** - Reset Zoom.
 
 **O** - Overlap all elements and back
+
+Known bugs:
+
+If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should.

--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,7 @@
 Adds the ability to zoom into Inpaint, Sketch, and Inpaint Sketch.
 
 Shortcuts:
-R - Reset Zoom.
-O - Overlap all elements and back
+
+**R** - Reset Zoom.
+
+**O** - Overlap all elements and back

--- a/README.MD
+++ b/README.MD
@@ -14,6 +14,9 @@ Shortcuts:
 
 **O** - Overlap all elements and back
 
-Known bugs:
+
+When you move the mouse beyond the picture boundary, the last action is canceled
+
+**Known bugs:**
 
 If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should.

--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,12 @@ Adds the ability to zoom into Inpaint, Sketch, and Inpaint Sketch.
 
 Shortcuts:
 
+**Shift + wheel(hold)** - Move canvas
+
+**Shift + wheel** - Scale canvas
+
+**Ctr + wheel** - Change brush size
+
 **R** - Reset Zoom.
 
 **O** - Overlap all elements and back

--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,5 @@
+Adds the ability to zoom into Inpaint, Sketch, and Inpaint Sketch.
+
+Shortcuts:
+R - Reset Zoom.
+O - Overlap all elements and back

--- a/README.MD
+++ b/README.MD
@@ -14,9 +14,10 @@ Shortcuts:
 
 **O** - Overlap all elements and back
 
-
-When you move the mouse beyond the picture boundary, the last action is canceled
+**Ctr-Z** - Undo last action
 
 **Known bugs:**
 
-If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should.
+1. If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should.
+
+2. Not my bug, the problem is with automatic1111. If you make something in sketch, then send it to inpaint or inpaint sketch , it breaks undo via shortcut and button. You need to delete the picture and load it back into the window, then everything will work

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -137,15 +137,15 @@ setTimeout(function () {
       document.removeEventListener("mousemove", handleMove);
       document.removeEventListener("mouseup", handleEnd);
       targetElement.style.pointerEvents = "auto";
-      targetElement.addEventListener("mouseleave", handleundo);
+      // targetElement.addEventListener("mouseleave", handleundo);
     }
 
-    function handleundo() {
-      document.removeEventListener("mouseleave", handleundo);
-      document
-        .querySelector(`${elemId} .svelte-s6ybro button:nth-child(1)`)
-        .click();
-    }
+    // function handleundo() {
+    //   document.removeEventListener("mouseleave", handleundo);
+    //   document
+    //     .querySelector(`${elemId} .svelte-s6ybro button:nth-child(1)`)
+    //     .click();
+    // }
 
     targetElement.addEventListener("mousedown", (e) => {
       if (e.shiftKey) {

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -2,18 +2,12 @@ setTimeout(function () {
   const sketchID = "#img2img_sketch";
   const inpaintID = "#img2maskimg";
   const inpaintSketchID = "#inpaint_sketch";
+  const img2imgTabsID = "#mode_img2img .tab-nav";
 
-  const sketchEl = document
-    .querySelector("body > gradio-app")
-    .shadowRoot.querySelector(sketchID);
-
-  const inpaintEl = document
-    .querySelector("body > gradio-app")
-    .shadowRoot.querySelector(inpaintID);
-
-  const inpaintSketchEl = document
-    .querySelector("body > gradio-app")
-    .shadowRoot.querySelector(inpaintSketchID);
+  const sketchEl = document.querySelector(sketchID);
+  const inpaintEl = document.querySelector(inpaintID);
+  const inpaintSketchEl = document.querySelector(inpaintSketchID);
+  const img2imgTabs = document.querySelector(img2imgTabsID);
 
   function applyZoomAndPan(targetElement, elemId) {
     let [zoomLevel, panX, panY] = [1, 0, 0];
@@ -27,13 +21,20 @@ setTimeout(function () {
     }
 
     // Overlap all elemnts
-    function toggleOverlap() {
+    function toggleOverlap(overlap = true) {
       const zIndex1 = "0";
       const zIndex2 = "99999";
+
+      if (overlap === false) {
+        targetElement.style.zIndex = zIndex1;
+        return;
+      }
 
       targetElement.style.zIndex =
         targetElement.style.zIndex !== zIndex2 ? zIndex2 : zIndex1;
     }
+
+    // Reset when close img
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "r" || e.key === "R" || e.key === "к" || e.key === "К") {
@@ -41,6 +42,14 @@ setTimeout(function () {
       }
       if (e.key === "o" || e.key === "O" || e.key === "щ" || e.key === "Щ") {
         toggleOverlap();
+      }
+    });
+
+    // Reset zoom when click on another tab
+    img2imgTabs.addEventListener("click", (e) => {
+      if (e.target.classList.contains("svelte-1g805jl")) {
+        toggleOverlap(false);
+        resetZoom();
       }
     });
 
@@ -65,18 +74,13 @@ setTimeout(function () {
       if (e.ctrlKey) {
         e.preventDefault();
 
-        const input = document
-          .querySelector("body > gradio-app")
-          .shadowRoot.querySelector(
-            `${elemId} > div.h-60.bg-gray-200 > div > div.z-50.top-10.right-2.justify-end.flex.gap-1.absolute > span > input`
-          );
+        const input = document.querySelector(
+          `${elemId} input[aria-label='Brush radius']`
+        );
 
         if (input == null) {
           document
-            .querySelector("body > gradio-app")
-            .shadowRoot.querySelector(
-              `${elemId} > div.h-60.bg-gray-200 > div > div.z-50.top-10.right-2.justify-end.flex.gap-1.absolute > span > button`
-            )
+            .querySelector(`${elemId} button[aria-label="Use brush"]`)
             .click();
         }
 
@@ -106,10 +110,7 @@ setTimeout(function () {
     function handleundo() {
       document.removeEventListener("mouseleave", handleundo);
       document
-        .querySelector("body > gradio-app")
-        .shadowRoot.querySelector(
-          `${elemId} > div.h-60.bg-gray-200 > div > div.z-50.top-2.right-2.justify-end.flex.gap-1.absolute > button:nth-child(1)`
-        )
+        .querySelector(`${elemId} .svelte-s6ybro button:nth-child(1)`)
         .click();
     }
 

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -9,6 +9,22 @@ setTimeout(function () {
   const inpaintSketchEl = document.querySelector(inpaintSketchID);
   const img2imgTabs = document.querySelector(img2imgTabsID);
 
+  // undo by Ctr-Z
+  function undoActiveTab(elemId) {
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "z" || e.key === "Z" || e.key === "я" || e.key === "Я") {
+        if (e.ctrlKey) {
+          const undoBtn = document.querySelector(
+            `${elemId} button[aria-label="Undo"]`
+          );
+          if (undoBtn) {
+            undoBtn.click();
+          }
+        }
+      }
+    });
+  }
+
   function applyZoomAndPan(targetElement, elemId) {
     let [zoomLevel, panX, panY] = [1, 0, 0];
 
@@ -35,6 +51,8 @@ setTimeout(function () {
     }
 
     // Reset when close img
+
+    undoActiveTab(elemId);
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "r" || e.key === "R" || e.key === "к" || e.key === "К") {

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -1,63 +1,128 @@
-// uses timeout because it does not load when it does not have this and i cant seem to use onload events probably because most things seem to be handled by javascript
 setTimeout(function () {
-  const element = document.querySelector("body > gradio-app").shadowRoot.querySelector("#img2maskimg");
-  let [zoomLevel, panX, panY] = [1, 0, 0];
-  element.addEventListener("wheel", (e) => {
-    if (e.shiftKey) {
-      e.preventDefault();
+  const sketchID = "#img2img_sketch";
+  const inpaintID = "#img2maskimg";
+  const inpaintSketchID = "#inpaint_sketch";
 
-      // handle zooming here panning will be handled by the mousemove event
-      const startZoomLevel = zoomLevel;
+  const sketchEl = document
+    .querySelector("body > gradio-app")
+    .shadowRoot.querySelector(sketchID);
 
-      // Calculate new zoom level + or - 0.1 based on direction of scroll amount should change based on zoom level if above 5 then 0.5 if below 5 then 0.1
-      const delta = zoomLevel > 3 ? 0.5 : 0.1;
-      zoomLevel = e.deltaY > 0 ? startZoomLevel - delta : startZoomLevel + delta;
+  const inpaintEl = document
+    .querySelector("body > gradio-app")
+    .shadowRoot.querySelector(inpaintID);
 
-      // max and min zoom level using clamp min is 0.5 and max is 10
-      zoomLevel = Math.min(Math.max(0.5, zoomLevel), 10);
+  const inpaintSketchEl = document
+    .querySelector("body > gradio-app")
+    .shadowRoot.querySelector(inpaintSketchID);
 
-      // update the zoom level
-      element.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
+  function applyZoomAndPan(targetElement, elemId) {
+    let [zoomLevel, panX, panY] = [1, 0, 0];
+
+    // Reset zoom to Default
+    function resetZoom() {
+      zoomLevel = 1;
+      panX = 0;
+      panY = 0;
+      targetElement.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
     }
-    if (e.ctrlKey) {
-      e.preventDefault();
 
-      const input = document.querySelector("body > gradio-app").shadowRoot.querySelector("#img2maskimg > div.h-60.bg-gray-200 > div > div.z-50.top-10.right-2.justify-end.flex.gap-1.absolute > span > input")
-      if (input == null) {
-        document.querySelector("body > gradio-app").shadowRoot.querySelector("#img2maskimg > div.h-60.bg-gray-200 > div > div.z-50.top-10.right-2.justify-end.flex.gap-1.absolute > span > button").click();
+    // Overlap all elemnts
+    function toggleOverlap() {
+      const zIndex1 = "0";
+      const zIndex2 = "99999";
+
+      targetElement.style.zIndex =
+        targetElement.style.zIndex !== zIndex2 ? zIndex2 : zIndex1;
+    }
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "r" || e.key === "R" || e.key === "к" || e.key === "К") {
+        resetZoom();
       }
-      let value = parseFloat(input.value);
-      value += e.deltaY > 0 ? -3 : 3;
-      input.value = value;
-      const changeEvent = new Event('change');
-      input.dispatchEvent(changeEvent);
-    }
-  });
+      if (e.key === "o" || e.key === "O" || e.key === "щ" || e.key === "Щ") {
+        toggleOverlap();
+      }
+    });
 
-  function handleMove(e) {
-    e.preventDefault();
-    panX += e.movementX;
-    panY += e.movementY;
-    element.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
-    element.style.pointerEvents = "none";
-  }
+    targetElement.addEventListener("wheel", (e) => {
+      if (e.shiftKey) {
+        e.preventDefault();
 
-  function handleEnd() {
-    document.removeEventListener("mousemove", handleMove);
-    document.removeEventListener("mouseup", handleEnd);
-    element.style.pointerEvents = "auto";
-    element.addEventListener("mouseleave", handleundo);
-  }
-  function handleundo() {
-    document.removeEventListener("mouseleave", handleundo);
-    document.querySelector("body > gradio-app").shadowRoot.querySelector("#img2maskimg > div.h-60.bg-gray-200 > div > div.z-50.top-2.right-2.justify-end.flex.gap-1.absolute > button:nth-child(1)").click();
-  }
+        // handle zooming here panning will be handled by the mousemove event
+        const startZoomLevel = zoomLevel;
 
-  element.addEventListener("mousedown", (e) => {
-    if (e.shiftKey) {
+        // Calculate new zoom level + or - 0.1 based on direction of scroll amount should change based on zoom level if above 5 then 0.5 if below 5 then 0.1
+        const delta = zoomLevel > 3 ? 0.5 : 0.1;
+        zoomLevel =
+          e.deltaY > 0 ? startZoomLevel - delta : startZoomLevel + delta;
+
+        // max and min zoom level using clamp min is 0.5 and max is 10
+        zoomLevel = Math.min(Math.max(0.5, zoomLevel), 10);
+
+        // update the zoom level
+        targetElement.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
+      }
+      if (e.ctrlKey) {
+        e.preventDefault();
+
+        const input = document
+          .querySelector("body > gradio-app")
+          .shadowRoot.querySelector(
+            `${elemId} > div.h-60.bg-gray-200 > div > div.z-50.top-10.right-2.justify-end.flex.gap-1.absolute > span > input`
+          );
+
+        if (input == null) {
+          document
+            .querySelector("body > gradio-app")
+            .shadowRoot.querySelector(
+              `${elemId} > div.h-60.bg-gray-200 > div > div.z-50.top-10.right-2.justify-end.flex.gap-1.absolute > span > button`
+            )
+            .click();
+        }
+
+        let value = parseFloat(input.value);
+        value += e.deltaY > 0 ? -3 : 3;
+        input.value = value;
+        const changeEvent = new Event("change");
+        input.dispatchEvent(changeEvent);
+      }
+    });
+
+    function handleMove(e) {
       e.preventDefault();
-      document.addEventListener("mousemove", handleMove);
-      document.addEventListener("mouseup", handleEnd);
+      panX += e.movementX;
+      panY += e.movementY;
+      targetElement.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
+      targetElement.style.pointerEvents = "none";
     }
-  });
+
+    function handleEnd() {
+      document.removeEventListener("mousemove", handleMove);
+      document.removeEventListener("mouseup", handleEnd);
+      targetElement.style.pointerEvents = "auto";
+      targetElement.addEventListener("mouseleave", handleundo);
+    }
+
+    function handleundo() {
+      document.removeEventListener("mouseleave", handleundo);
+      document
+        .querySelector("body > gradio-app")
+        .shadowRoot.querySelector(
+          `${elemId} > div.h-60.bg-gray-200 > div > div.z-50.top-2.right-2.justify-end.flex.gap-1.absolute > button:nth-child(1)`
+        )
+        .click();
+    }
+
+    targetElement.addEventListener("mousedown", (e) => {
+      if (e.shiftKey) {
+        e.preventDefault();
+        document.addEventListener("mousemove", handleMove);
+        document.addEventListener("mouseup", handleEnd);
+      }
+    });
+  }
+
+  applyZoomAndPan(sketchEl, sketchID);
+  applyZoomAndPan(inpaintEl, inpaintID);
+  applyZoomAndPan(inpaintSketchEl, inpaintSketchID);
 }, 3000);

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -51,15 +51,30 @@ setTimeout(function () {
     }
 
     // Reset when close img
-
     undoActiveTab(elemId);
 
+    // Reset zoom by press R and overlap elements by O
     document.addEventListener("keydown", (e) => {
       if (e.key === "r" || e.key === "R" || e.key === "к" || e.key === "К") {
         resetZoom();
       }
       if (e.key === "o" || e.key === "O" || e.key === "щ" || e.key === "Щ") {
         toggleOverlap();
+      }
+    });
+
+    // open brush colors
+    document.addEventListener("keypress", (e) => {
+      if (e.key == "Q" || e.key == "q" || e.key == "й" || e.key == "Й") {
+        const colorBtn = document.querySelector(
+          `${elemId} button[aria-label="Select brush color"]`
+        );
+
+        if (!colorBtn) {
+          return;
+        } else {
+          colorBtn.click();
+        }
       }
     });
 


### PR DESCRIPTION
Reworked the code, added support for zoom for Sketch and Inpaint Sketch, added two shortcuts to reset zoom and overlap all elements (works the other way around)

added shortcuts to overlap elements and reset zoom
R - reset zoom
O - overlap all elements and back

Upd 25.03
Now when you change tabs, the zoom will be reset, corrected the code to work on the new version automatic1111
Add Ctr-Z to undo last action
Add Q to open color panel