### PR TITLE
Fix contextual menu, removed old code, improve hotkeys, fix 1st Known bugs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,6 +12,8 @@ Shortcuts:
 
 **R** - Reset Zoom.
 
+**Q** - Open/Close color panel
+
 **O** - Overlap all elements and back
 
 **Ctr-Z** - Undo last action

--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ Default hotkeys:
 
 **Known bugs:**
 
-1. If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should.
+1. If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should. ( Solved )
 
 2. Not my bug, the problem is with automatic1111. If you make something in sketch, then send it to inpaint or inpaint sketch , it breaks undo via shortcut and button. You need to delete the picture and load it back into the window, then everything will work
 
@@ -52,6 +52,6 @@ Default hotkeys:
 
 **Известные баги:**
 
-1. Если нажать на крестик и удалить картинку в режиме зума, есть вероятность, что картинка будет обрезана. Необходимо, сбросить зум, нажать на крестик и загрузить картинку, тогда все будет работать как надо.
+1. Если нажать на крестик и удалить картинку в режиме зума, есть вероятность, что картинка будет обрезана. Необходимо, сбросить зум, нажать на крестик и загрузить картинку, тогда все будет работать как надо. ( Решенно )
 
 2. Это не мой баг, проблема связана с automatic1111. Если вы делаете что-то в скетче, затем отправляете это в inpaint или inpaint sketch через кнопку( в любом порядке ), он ломает отмену через хоткей и кнопку. Вам нужно закрыть картинку и загрузить ёё обратно, тогда все будет работать.

--- a/README.MD
+++ b/README.MD
@@ -23,14 +23,14 @@ Default hotkeys:
 
 **Known bugs:**
 
-1. If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should. ( Solved )
+1. If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should. **( Solved )**
 
 2. Not my bug, the problem is with automatic1111. If you make something in sketch, then send it to inpaint or inpaint sketch , it breaks undo via shortcut and button. You need to delete the picture and load it back into the window, then everything will work
 
 # RU
 Расширение [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
 
-Добавляет возможность зума Inpaint, Sketch и Inpaint Sketch и горячие клавиши для удобства в работе.
+Добавляет возможность зума в Inpaint, Sketch и Inpaint Sketch и горячие клавиши для удобства в работе.
 
 Вы можете редактировать горячие клавиши по своему усмотрению, **щелкнув правой кнопкой мыши** в **Inpaint , Sketch и Inpaint Sketch, на области изображения**, и откроется контекстное меню, где вы можете настроить горячие клавиши по своему усмотрению.
 
@@ -52,6 +52,8 @@ Default hotkeys:
 
 **Известные баги:**
 
-1. Если нажать на крестик и удалить картинку в режиме зума, есть вероятность, что картинка будет обрезана. Необходимо, сбросить зум, нажать на крестик и загрузить картинку, тогда все будет работать как надо. ( Решенно )
+1. Если нажать на крестик и удалить картинку в режиме зума, есть вероятность, что картинка будет обрезана. Необходимо, сбросить зум, нажать на крестик и загрузить картинку, тогда все будет работать как надо. **( Решенно )**
 
 2. Это не мой баг, проблема связана с automatic1111. Если вы делаете что-то в скетче, затем отправляете это в inpaint или inpaint sketch через кнопку( в любом порядке ), он ломает отмену через хоткей и кнопку. Вам нужно закрыть картинку и загрузить ёё обратно, тогда все будет работать.
+
+3. Хоткеи работают только на Английской раскладке

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,4 @@
+# EN
 An extension of [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
 
 Adds the ability to zoom into Inpaint, Sketch, and Inpaint Sketch.
@@ -25,3 +26,32 @@ Default hotkeys:
 1. If you click on the cross and delete the picture in zoom mode, there is a chance that the picture will be cropped. It is necessary to click on the cross and load the picture again without zooming, then everything will work as it should.
 
 2. Not my bug, the problem is with automatic1111. If you make something in sketch, then send it to inpaint or inpaint sketch , it breaks undo via shortcut and button. You need to delete the picture and load it back into the window, then everything will work
+
+# RU
+Расширение [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui).
+
+Добавляет возможность зума Inpaint, Sketch и Inpaint Sketch и горячие клавиши для удобства в работе.
+
+Вы можете редактировать горячие клавиши по своему усмотрению, **щелкнув правой кнопкой мыши** в **Inpaint , Sketch и Inpaint Sketch, на области изображения**, и откроется контекстное меню, где вы можете настроить горячие клавиши по своему усмотрению.
+
+Горячие клавиши по умолчанию:
+
+**Shift + колесо (удерживать)** - Переместить холст
+
+**Shift + колесо** - Масштабировать холст
+
+**Ctr + колесо** - Изменить размер кисти
+
+**R** - Сброс зума.
+
+**Q** - Открыть/Закрыть выбор цвета 
+
+**O** - Перекрыть все элементы и обратно
+
+**Ctr-Z** - Отменить последнее действие
+
+**Известные баги:**
+
+1. Если нажать на крестик и удалить картинку в режиме зума, есть вероятность, что картинка будет обрезана. Необходимо, сбросить зум, нажать на крестик и загрузить картинку, тогда все будет работать как надо.
+
+2. Это не мой баг, проблема связана с automatic1111. Если вы делаете что-то в скетче, затем отправляете это в inpaint или inpaint sketch через кнопку( в любом порядке ), он ломает отмену через хоткей и кнопку. Вам нужно закрыть картинку и загрузить ёё обратно, тогда все будет работать.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
-This version of canvas-zoom only works with the March 25th and later versions of the WebUI.
+**This version of canvas-zoom only works with the March 25th and later versions of the WebUI.**
 
-If you haven't updated, you can install from this commit https://github.com/richrobber2/canvas-zoom/tree/33b690c2ccec1bf436d4d37af1c6998209a860b6.
+**If you haven't updated, you can install from this commit** https://github.com/richrobber2/canvas-zoom/tree/33b690c2ccec1bf436d4d37af1c6998209a860b6.
 
 # EN
 An extension of [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui)

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,7 @@
+This version of canvas-zoom only works with the March 25th and later versions of the WebUI.
+
+If you haven't updated, you can install from this commit https://github.com/richrobber2/canvas-zoom/tree/33b690c2ccec1bf436d4d37af1c6998209a860b6.
+
 # EN
 An extension of [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui)
 

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -15,7 +15,7 @@
     return JSON.parse(configString);
   }
 
-  // Update the config, redraw the object, and save it to localStorage
+  // Update the config, and save it to localStorage
   function updateConfigAndSave(key, value) {
     const config = getConfigFromLocalStorage();
     config[key] = value;
@@ -191,6 +191,7 @@
     const menu = document.createElement("div");
     menu.style.listStyleType = "None";
     menu.className = "context-menu";
+    menu.style.zIndex = "99999";
     document.body.appendChild(menu);
     return menu;
   })();
@@ -216,9 +217,9 @@
       e.preventDefault();
       menuItems = [
         {
-          action: "settings", // The action to perform when the item is clicked
+          action: "Change hotkeys", // The action to perform when the item is clicked
           hotkey: "⚙", // The hotkey to display next to the item in this case. It's the gear icon
-          label: "Settings", // The text to display for the item
+          label: "Change hotkeys", // The text to display for the item
         },
         // handle undo hotkey
         {
@@ -272,6 +273,20 @@
     contextMenu.style.display = "none";
   });
 
+  // Hide the context menu on left-click
+  let timeoutId;
+  contextMenu.addEventListener("mouseleave", () => {
+    // Set the timer for 1 second, after which the item will disappear
+    timeoutId = setTimeout(() => {
+      contextMenu.style.display = "none";
+    }, 200);
+  });
+
+  contextMenu.addEventListener("mouseenter", () => {
+    // If the mouse returns to an item before the timer has expired, cancel it
+    clearTimeout(timeoutId);
+  });
+
   /**
    * Trigger undo action on the active tab when Ctrl + Z is pressed.
    * @param {string} elemId - The ID of the element to target.
@@ -312,7 +327,21 @@
       const colorBtn = document.querySelector(
         `${elemId} button[aria-label="Select brush color"]`
       );
-      colorBtn ? colorBtn.click() : null;
+
+      const colorInput = document.querySelector(
+        `${elemId} input[aria-label="Brush color"]`
+      );
+
+      if (!colorInput) {
+        colorBtn ? colorBtn.click() : null;
+      }
+      // Open color menu
+      setTimeout(() => {
+        const colorInput = document.querySelector(
+          `${elemId} input[aria-label="Brush color"]`
+        );
+        colorInput ? colorInput.click() : colorBtn;
+      }, 0);
     }
     /**
      * Reset zoom and pan to default values.
@@ -328,7 +357,6 @@
      * Toggle element overlap.
      */
     function toggleOverlap() {
-      console.log("toggle overlap has been called");
       const zIndex1 = "0";
       const zIndex2 = "99999";
 
@@ -362,10 +390,10 @@
     /**
      * Disable overlap when open context menu open
      **/
-    targetElement.addEventListener("contextmenu", (e) => {
-      e.preventDefault();
-      targetElement.style.zIndex = 0;
-    });
+    // targetElement.addEventListener("contextmenu", (e) => {
+    //   e.preventDefault();
+    //   targetElement.style.zIndex = 0;
+    // });
 
     undoActiveTab(elemId);
 
@@ -387,7 +415,7 @@
       }
       if (
         e.key.toLocaleLowerCase() === hotkeysConfig.openBrushSetting ||
-        e.key === hotkeysConfig.overlap
+        e.key === hotkeysConfig.openBrushSetting
       ) {
         toogleBrushPanel();
       }

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -1,12 +1,41 @@
 (async () => {
   // Wait for the specified delay
   await new Promise((resolve) => setTimeout(resolve, 3000));
-  const hotkeysConfig = {
-    undo: "z",
-    resetZoom: "r",
-    overlap: "o",
-    openBrushSetting: "q",
-  };
+
+  // LocalStorage functions
+
+  // Save the config to localStorage
+  function saveConfigToLocalStorage(config) {
+    localStorage.setItem("hotkeysConfig", JSON.stringify(config));
+  }
+
+  // Retrieve the config from localStorage and return as an object
+  function getConfigFromLocalStorage() {
+    const configString = localStorage.getItem("hotkeysConfig");
+    return JSON.parse(configString);
+  }
+
+  // Update the config, redraw the object, and save it to localStorage
+  function updateConfigAndSave(key, value) {
+    const config = getConfigFromLocalStorage();
+    config[key] = value;
+    saveConfigToLocalStorage(config);
+  }
+  let hotkeysConfig;
+  const configFromLocalStorage = getConfigFromLocalStorage();
+  console.log(configFromLocalStorage);
+
+  if (configFromLocalStorage == null) {
+    hotkeysConfig = {
+      undo: "z",
+      resetZoom: "r",
+      overlap: "o",
+      openBrushSetting: "q",
+    };
+    saveConfigToLocalStorage(hotkeysConfig);
+  } else {
+    hotkeysConfig = getConfigFromLocalStorage();
+  }
 
   const sketchID = "#img2img_sketch";
   const inpaintID = "#img2maskimg";
@@ -76,6 +105,7 @@
       if (hotkey !== null) {
         // Update the hotkey in the config
         hotkeysConfig.undo = hotkey;
+        updateConfigAndSave("undo", hotkey);
       }
     },
     resetZoom: () => {
@@ -83,6 +113,7 @@
       if (hotkey !== null) {
         // Update the hotkey in the config
         hotkeysConfig.resetZoom = hotkey;
+        updateConfigAndSave("resetZoom", hotkey);
       }
     },
     overlap: () => {
@@ -90,6 +121,7 @@
       if (hotkey !== null) {
         // Update the hotkey in the config
         hotkeysConfig.overlap = hotkey;
+        updateConfigAndSave("overlap", hotkey);
       }
     },
     openBrushSetting: () => {
@@ -98,6 +130,7 @@
       if (hotkey !== null) {
         // Update the hotkey in the config
         hotkeysConfig.openBrushSetting = hotkey;
+        updateConfigAndSave("openBrushSetting", hotkey);
       }
     },
   };

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -137,15 +137,15 @@ setTimeout(function () {
       document.removeEventListener("mousemove", handleMove);
       document.removeEventListener("mouseup", handleEnd);
       targetElement.style.pointerEvents = "auto";
-      targetElement.addEventListener("mouseleave", handleundo);
+      // targetElement.addEventListener("mouseleave", handleundo);
     }
 
-    function handleundo() {
-      document.removeEventListener("mouseleave", handleundo);
-      document
-        .querySelector(`${elemId} .svelte-s6ybro button:nth-child(1)`)
-        .click();
-    }
+    // function handleundo() {
+    //   document.removeEventListener("mouseleave", handleundo);
+    //   document
+    //     .querySelector(`${elemId} .svelte-s6ybro button:nth-child(1)`)
+    //     .click();
+    // }
 
     targetElement.addEventListener("mousedown", (e) => {
       if (e.shiftKey) {

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -362,7 +362,7 @@
     /**
      * Disable overlap when open context menu open
      **/
-    document.addEventListener("contextmenu", (e) => {
+    targetElement.addEventListener("contextmenu", (e) => {
       e.preventDefault();
       targetElement.style.zIndex = 0;
     });

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -393,25 +393,6 @@
       }
     });
 
-    // Open brush colors
-    document.addEventListener("keypress", (e) => {
-      // use hotkeys config upper and lower case
-      if (
-        e.key === hotkeysConfig.brushColors ||
-        e.key === hotkeysConfig.brushColors
-      ) {
-        const colorBtn = document.querySelector(
-          `${elemId} button[aria-label="Select brush color"]`
-        );
-
-        if (!colorBtn) {
-          return;
-        } else {
-          colorBtn.click();
-        }
-      }
-    });
-
     // Reset zoom when click on another tab
     img2imgTabs.addEventListener("click", (e) => {
       if (e.target.classList.contains("svelte-1g805jl")) {

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -387,6 +387,15 @@
       input.dispatchEvent(changeEvent);
     }
 
+    //Reset Zoom when upload image, To get rid of the bug, the picture becomes cropped
+    fileInput = document.querySelector(
+      `${elemId} input[type="file"][accept="image/*"].svelte-116rqfv`
+    );
+    fileInput.addEventListener("click", function () {
+      resetZoom();
+      console.log("choosen");
+    });
+
     /**
      * Disable overlap when open context menu open
      **/

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -324,21 +324,47 @@
      * Toggle Brush Panel
      */
     function toogleBrushPanel() {
+      let colorId;
+
+      // Get active tab to avoid some bug
+      function getActiveTab() {
+        const tabs = img2imgTabs.querySelectorAll("button");
+
+        for (let tab of tabs) {
+          if (tab.classList.contains("selected")) {
+            return tab;
+          }
+        }
+      }
+
+      //
+      const activeTab = getActiveTab();
+
+      // Select current color panel
+      if (activeTab.innerText === "Sketch") {
+        colorId = sketchID;
+      } else if (activeTab.innerText === "Inpaint sketch") {
+        colorId = inpaintSketchID;
+      } else {
+        return;
+      }
+
       const colorBtn = document.querySelector(
-        `${elemId} button[aria-label="Select brush color"]`
+        `${colorId} button[aria-label="Select brush color"]`
       );
 
       const colorInput = document.querySelector(
-        `${elemId} input[aria-label="Brush color"]`
+        `${colorId} input[aria-label="Brush color"]`
       );
 
       if (!colorInput) {
         colorBtn ? colorBtn.click() : null;
       }
+
       // Open color menu
       setTimeout(() => {
         const colorInput = document.querySelector(
-          `${elemId} input[aria-label="Brush color"]`
+          `${colorId} input[aria-label="Brush color"]`
         );
         colorInput ? colorInput.click() : colorBtn;
       }, 0);
@@ -393,7 +419,6 @@
     );
     fileInput.addEventListener("click", function () {
       resetZoom();
-      console.log("choosen");
     });
 
     /**

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -1,19 +1,259 @@
-setTimeout(function () {
+(async () => {
+  // Wait for the specified delay
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  const hotkeysConfig = {
+    undo: "z",
+    resetZoom: "r",
+    overlap: "o",
+    openBrushSetting: "q",
+  };
+
   const sketchID = "#img2img_sketch";
   const inpaintID = "#img2maskimg";
   const inpaintSketchID = "#inpaint_sketch";
   const img2imgTabsID = "#mode_img2img .tab-nav";
 
-  const sketchEl = document.querySelector(sketchID);
-  const inpaintEl = document.querySelector(inpaintID);
-  const inpaintSketchEl = document.querySelector(inpaintSketchID);
-  const img2imgTabs = document.querySelector(img2imgTabsID);
+  const [sketchEl, inpaintEl, inpaintSketchEl, img2imgTabs] = await Promise.all(
+    [
+      document.querySelector(sketchID),
+      document.querySelector(inpaintID),
+      document.querySelector(inpaintSketchID),
+      document.querySelector(img2imgTabsID),
+    ]
+  );
+  function askForHotkey() {
+    const validKeys = /^[A-Za-z0-9]{1}$/; // A regex pattern to match a string containing a single alphanumeric character
+    const reservedKeys = [
+      hotkeysConfig.resetZoom,
+      hotkeysConfig.overlap,
+      hotkeysConfig.openBrushSetting,
+      hotkeysConfig.undo,
+    ];
 
-  // undo by Ctr-Z
+    let hotkey = "";
+
+    while (!validKeys.test(hotkey)) {
+      hotkey = window.prompt("Please enter a valid hotkey:");
+
+      if (!hotkey) {
+        // User canceled the prompt
+        return null;
+      }
+
+      if (!validKeys.test(hotkey)) {
+        window.alert("Invalid hotkey. Please enter 1 alphanumeric character.");
+      } else if (reservedKeys.includes(hotkey)) {
+        window.alert(
+          "This hotkey is already in use. Please enter a different hotkey."
+        );
+        hotkey = "";
+      } else if (hotkey === " ") {
+        window.alert(
+          "This hotkey is not able to be used. Please enter a different hotkey."
+        );
+        hotkey = "";
+      }
+    }
+
+    return hotkey;
+  }
+
+  // Define action functions for modal creation
+  const actions = {
+    settings: () => {
+      createModal({
+        title: "Settings",
+        content: "Settings content",
+        actions: [
+          {
+            label: "Close",
+          },
+        ],
+      });
+    },
+    undo: () => {
+      const hotkey = askForHotkey();
+      if (hotkey !== null) {
+        // Update the hotkey in the config
+        hotkeysConfig.undo = hotkey;
+      }
+    },
+    resetZoom: () => {
+      const hotkey = askForHotkey();
+      if (hotkey !== null) {
+        // Update the hotkey in the config
+        hotkeysConfig.resetZoom = hotkey;
+      }
+    },
+    overlap: () => {
+      const hotkey = askForHotkey();
+      if (hotkey !== null) {
+        // Update the hotkey in the config
+        hotkeysConfig.overlap = hotkey;
+      }
+    },
+    openBrushSetting: () => {
+      console.log("HI");
+      const hotkey = askForHotkey();
+      if (hotkey !== null) {
+        // Update the hotkey in the config
+        hotkeysConfig.openBrushSetting = hotkey;
+      }
+    },
+  };
+
+  // create an array to hold the modal elements
+  const modals = [];
+  function createModal({ title = "", content = "", actions = [] }) {
+    // Close any existing modals
+    modals.forEach((modal) => modal.remove());
+    // Create modal elements
+    const modal = document.createElement("div");
+    const modalOverlay = document.createElement("div");
+    const modalContainer = document.createElement("div");
+    const modalTitle = document.createElement("h3");
+    const modalContent = document.createElement("div");
+    const modalActions = document.createElement("div");
+
+    // Set class names
+    modal.className = "modal";
+    modalOverlay.className = "modal-overlay";
+    modalContainer.className = "modal-container";
+    modalTitle.className = "modal-title";
+    modalContent.className = "modal-content";
+    modalActions.className = "modal-actions";
+
+    // Set the title and content
+    modalTitle.textContent = title;
+    modalContent.innerHTML = content;
+
+    // Add actions
+    actions.forEach((action) => {
+      const button = document.createElement("button");
+      button.textContent = action.label;
+      button.className = action.class || "";
+
+      modalActions.appendChild(button);
+      // add the modal to the modals array
+      modals.push(modal);
+    });
+
+    // Assemble the modal
+    modalContainer.appendChild(modalTitle);
+    modalContainer.appendChild(modalContent);
+    modalContainer.appendChild(modalActions);
+    modal.appendChild(modalOverlay);
+    modal.appendChild(modalContainer);
+    document.body.appendChild(modal);
+
+    // Close the modal
+    function closeModal() {
+      modal.remove();
+    }
+
+    // Close the modal when clicking outside the container
+    modalOverlay.addEventListener("click", closeModal);
+    return modal;
+  }
+
+  const contextMenu = (() => {
+    const menu = document.createElement("div");
+    menu.style.listStyleType = "None";
+    menu.className = "context-menu";
+    document.body.appendChild(menu);
+    return menu;
+  })();
+
+  const generateContextMenuItems = (items) =>
+    items
+      .map(
+        (item) =>
+          `<li data-action="${item.action}">
+             <span><b>${item.hotkey.toUpperCase()}</b></span>
+             ${item.label}
+           </li>`
+      )
+      .join("");
+
+  document.addEventListener("contextmenu", (e) => {
+    let menuItems = [];
+    if (
+      e.target.closest(sketchID) ||
+      e.target.closest(inpaintID) ||
+      e.target.closest(inpaintSketchID)
+    ) {
+      e.preventDefault();
+      menuItems = [
+        {
+          action: "settings", // The action to perform when the item is clicked
+          hotkey: "⚙", // The hotkey to display next to the item in this case. It's the gear icon
+          label: "Settings", // The text to display for the item
+        },
+        // handle undo hotkey
+        {
+          action: "undo",
+          hotkey: hotkeysConfig.undo,
+          label: "Undo",
+        },
+        {
+          action: "resetZoom",
+          hotkey: hotkeysConfig.resetZoom,
+          label: "Reset Zoom",
+        },
+        {
+          action: "overlap",
+          hotkey: hotkeysConfig.overlap,
+          label: "Toggle Overlap",
+        },
+        {
+          action: "openBrushSetting",
+          hotkey: hotkeysConfig.openBrushSetting,
+          label: "Open color settings",
+        },
+      ];
+    } else if (
+      e.target.closest(inpaintID) ||
+      e.target.closest(inpaintSketchID)
+    ) {
+      e.preventDefault();
+      menuItems = [];
+    } else {
+      contextMenu.style.display = "none";
+      return;
+    }
+
+    contextMenu.innerHTML = generateContextMenuItems(menuItems);
+    contextMenu.style.display = "block";
+    contextMenu.style.left = `${e.pageX}px`;
+    contextMenu.style.top = `${e.pageY}px`;
+  });
+  contextMenu.addEventListener("click", (e) => {
+    // remove the event listeners
+    const action = e.target.closest("li").dataset.action;
+    // Check if the action exists in the actions object and run the corresponding function
+    if (actions.hasOwnProperty(action)) {
+      actions[action]();
+    }
+  });
+
+  // Hide the context menu on left-click
+  document.addEventListener("click", () => {
+    contextMenu.style.display = "none";
+  });
+
+  /**
+   * Trigger undo action on the active tab when Ctrl + Z is pressed.
+   * @param {string} elemId - The ID of the element to target.
+   */
   function undoActiveTab(elemId) {
     document.addEventListener("keydown", (e) => {
-      if (e.key === "z" || e.key === "Z" || e.key === "я" || e.key === "Я") {
+      // undo based on hotkeys config upper and lower case
+      if (
+        e.key === hotkeysConfig.undo ||
+        e.key === hotkeysConfig.undo.toUpperCase()
+      ) {
         if (e.ctrlKey) {
+          e.preventDefault();
           const undoBtn = document.querySelector(
             `${elemId} button[aria-label="Undo"]`
           );
@@ -25,10 +265,27 @@ setTimeout(function () {
     });
   }
 
+  /**
+   * Apply zoom and pan functionality to a target element.
+   * @param {HTMLElement} targetElement - The element to apply zoom and pan functionality to.
+   * @param {string} elemId - The ID of the element to target.
+   */
   function applyZoomAndPan(targetElement, elemId) {
     let [zoomLevel, panX, panY] = [1, 0, 0];
 
-    // Reset zoom to Default
+    // helper functions
+    /**
+     * Toggle Brush Panel
+     */
+    function toogleBrushPanel() {
+      const colorBtn = document.querySelector(
+        `${elemId} button[aria-label="Select brush color"]`
+      );
+      colorBtn ? colorBtn.click() : null;
+    }
+    /**
+     * Reset zoom and pan to default values.
+     */
     function resetZoom() {
       zoomLevel = 1;
       panX = 0;
@@ -36,36 +293,82 @@ setTimeout(function () {
       targetElement.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
     }
 
-    // Overlap all elemnts
-    function toggleOverlap(overlap = true) {
+    /**
+     * Toggle element overlap.
+     */
+    function toggleOverlap() {
+      console.log("toggle overlap has been called");
       const zIndex1 = "0";
       const zIndex2 = "99999";
-
-      if (overlap === false) {
-        targetElement.style.zIndex = zIndex1;
-        return;
-      }
 
       targetElement.style.zIndex =
         targetElement.style.zIndex !== zIndex2 ? zIndex2 : zIndex1;
     }
 
-    // Reset when close img
+    /**
+     * Adjust brush size.
+     * @param {string} elemId - The ID of the element to target.
+     * @param {number} deltaY - The scroll delta.
+     */
+    function adjustBrushSize(elemId, deltaY) {
+      const input = document.querySelector(
+        `${elemId} input[aria-label='Brush radius']`
+      );
+
+      if (input == null) {
+        document
+          .querySelector(`${elemId} button[aria-label="Use brush"]`)
+          .click();
+      }
+
+      let value = parseFloat(input.value);
+      value += deltaY > 0 ? -3 : 3;
+      input.value = value;
+      const changeEvent = new Event("change");
+      input.dispatchEvent(changeEvent);
+    }
+
+    /**
+     * Disable overlap when open context menu open
+     **/
+    document.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      targetElement.style.zIndex = 0;
+    });
+
     undoActiveTab(elemId);
 
-    // Reset zoom by press R and overlap elements by O
+    // Reset zoom when pressing R key and toggle overlap when pressing O key
+    // Open brush panel when pressing Q
     document.addEventListener("keydown", (e) => {
-      if (e.key === "r" || e.key === "R" || e.key === "к" || e.key === "К") {
+      // use hotkeys config upper and lower case
+      if (
+        e.key.toLocaleLowerCase() === hotkeysConfig.resetZoom ||
+        e.key === hotkeysConfig.resetZoom
+      ) {
         resetZoom();
       }
-      if (e.key === "o" || e.key === "O" || e.key === "щ" || e.key === "Щ") {
+      if (
+        e.key.toLocaleLowerCase() === hotkeysConfig.overlap ||
+        e.key === hotkeysConfig.overlap
+      ) {
         toggleOverlap();
+      }
+      if (
+        e.key.toLocaleLowerCase() === hotkeysConfig.openBrushSetting ||
+        e.key === hotkeysConfig.overlap
+      ) {
+        toogleBrushPanel();
       }
     });
 
-    // open brush colors
+    // Open brush colors
     document.addEventListener("keypress", (e) => {
-      if (e.key == "Q" || e.key == "q" || e.key == "й" || e.key == "Й") {
+      // use hotkeys config upper and lower case
+      if (
+        e.key === hotkeysConfig.brushColors ||
+        e.key === hotkeysConfig.brushColors
+      ) {
         const colorBtn = document.querySelector(
           `${elemId} button[aria-label="Select brush color"]`
         );
@@ -90,41 +393,33 @@ setTimeout(function () {
       if (e.shiftKey) {
         e.preventDefault();
 
-        // handle zooming here panning will be handled by the mousemove event
+        // Handle zooming with shift key pressed
         const startZoomLevel = zoomLevel;
 
-        // Calculate new zoom level + or - 0.1 based on direction of scroll amount should change based on zoom level if above 5 then 0.5 if below 5 then 0.1
-        const delta = zoomLevel > 3 ? 0.5 : 0.1;
+        // Calculate new zoom level based on scroll direction and current zoom level
+        // - Add or subtract 0.1 if the zoom level is below 3
+        // - Add or subtract 0.5 if the zoom level is 3 or above
+        const delta = zoomLevel >= 3 ? 0.5 : 0.1;
         zoomLevel =
           e.deltaY > 0 ? startZoomLevel - delta : startZoomLevel + delta;
 
-        // max and min zoom level using clamp min is 0.5 and max is 10
-        zoomLevel = Math.min(Math.max(0.5, zoomLevel), 10);
+        // Clamp the zoom level between 0.5 and 10
+        zoomLevel = Math.max(0.5, Math.min(zoomLevel, 10));
 
-        // update the zoom level
+        // Update the target element's transform property to apply the new zoom level
         targetElement.style.transform = `scale(${zoomLevel}) translate(${panX}px, ${panY}px)`;
-      }
-      if (e.ctrlKey) {
+      } else if (e.ctrlKey) {
         e.preventDefault();
-
-        const input = document.querySelector(
-          `${elemId} input[aria-label='Brush radius']`
-        );
-
-        if (input == null) {
-          document
-            .querySelector(`${elemId} button[aria-label="Use brush"]`)
-            .click();
-        }
-
-        let value = parseFloat(input.value);
-        value += e.deltaY > 0 ? -3 : 3;
-        input.value = value;
-        const changeEvent = new Event("change");
-        input.dispatchEvent(changeEvent);
+        // Handle brush size adjustment with ctrl key pressed
+        // Increase or decrease brush size based on scroll direction
+        adjustBrushSize(elemId, e.deltaY);
       }
     });
 
+    /**
+     * Handle the move event for pan functionality. Updates the panX and panY variables and applies the new transform to the target element.
+     * @param {MouseEvent} e - The mouse event.
+     */
     function handleMove(e) {
       e.preventDefault();
       panX += e.movementX;
@@ -133,20 +428,14 @@ setTimeout(function () {
       targetElement.style.pointerEvents = "none";
     }
 
+    /**
+     * Handle the end event for pan functionality. Removes the event listeners. Enables pointer events.
+     */
     function handleEnd() {
       document.removeEventListener("mousemove", handleMove);
       document.removeEventListener("mouseup", handleEnd);
       targetElement.style.pointerEvents = "auto";
-      // targetElement.addEventListener("mouseleave", handleundo);
     }
-
-    // function handleundo() {
-    //   document.removeEventListener("mouseleave", handleundo);
-    //   document
-    //     .querySelector(`${elemId} .svelte-s6ybro button:nth-child(1)`)
-    //     .click();
-    // }
-
     targetElement.addEventListener("mousedown", (e) => {
       if (e.shiftKey) {
         e.preventDefault();
@@ -159,4 +448,4 @@ setTimeout(function () {
   applyZoomAndPan(sketchEl, sketchID);
   applyZoomAndPan(inpaintEl, inpaintID);
   applyZoomAndPan(inpaintSketchEl, inpaintSketchID);
-}, 3000);
+})();

--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -23,7 +23,6 @@
   }
   let hotkeysConfig;
   const configFromLocalStorage = getConfigFromLocalStorage();
-  console.log(configFromLocalStorage);
 
   if (configFromLocalStorage == null) {
     hotkeysConfig = {
@@ -125,7 +124,6 @@
       }
     },
     openBrushSetting: () => {
-      console.log("HI");
       const hotkey = askForHotkey();
       if (hotkey !== null) {
         // Update the hotkey in the config

--- a/style.css
+++ b/style.css
@@ -1,0 +1,104 @@
+.context-menu {
+  display: none;
+  position: absolute;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  padding: 8px;
+  z-index: 1000;
+  font-size: 14px;
+}
+
+.context-menu ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.context-menu li {
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.context-menu li:hover {
+  background-color: #f1f1f1;
+}
+
+/* Modal overlay */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+/* Modal container */
+.modal-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  border-radius: 4px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 1001;
+  max-width: 90%;
+  overflow: auto;
+}
+
+/* Modal title */
+.modal-title {
+  margin: 0;
+  margin-bottom: 15px;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+/* Modal content */
+.modal-content {
+  margin-bottom: 15px;
+}
+
+/* Modal actions */
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+/* Cancel button */
+.cancel-button {
+  background-color: #ccc;
+  border: none;
+  border-radius: 3px;
+  padding: 5px 15px;
+  color: #333;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.3s;
+}
+
+.cancel-button:hover {
+  background-color: #bbb;
+}
+
+/* Submit button */
+.submit-button {
+  background-color: #007bff;
+  border: none;
+  border-radius: 3px;
+  padding: 5px 15px;
+  color: white;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background-color 0.3s;
+}
+
+.submit-button:hover {
+  background-color: #0069d9;
+}
+
+


### PR DESCRIPTION
When I made it so that the picture would have an "overlap" turned off when the settings menu was on, the context menu on the whole page broke.

Fixed this error, as well as removed the old code.

UPD 19:11: 
1) edited comments
2) Made a contextual me with a large index, so that it would overlap the picture
3) Made the context menu close in 200ms after you moved the mouse away from it.
3) Changed menu Settings to Change hotkeys so it would be understandable and made it so the user would not fall in modal window
4) Changed a little Open Brush Color, now when you click on the color selection panel opens, I think it is more convenient
5) Fixed bug with duplicate overlap and open brush color

UPD 20:22:
1) Fix bug when the user uploads a file we reset the zoom and the picture is always loaded correctly without the zoom.
2) Remake README.MD for EN and RU users