### PR TITLE
Get Image Dimension tool fix

### DIFF
--- a/javascript/canvas-zoom.js
+++ b/javascript/canvas-zoom.js
@@ -459,7 +459,7 @@ const defaultHotkeysConfig = {
     // Create give size button
     if (!isGetSizeImgBtnExists) {
       getImgDataBtn.addEventListener("click", () => {
-        const tabID = getTabId();
+        const tabID = getTabId(elements);
         const canvas = document.querySelector(`${tabID} canvas`);
         const img = document.querySelector("#img2img_image img");
         const imgUpload = document.querySelector("#img_inpaint_base img");


### PR DESCRIPTION
When I click on this tool:
![изображение](https://github.com/richrobber2/canvas-zoom/assets/132840938/70c60a63-6603-4cc5-aa7e-10836453ecf6)
I am getting errors in the console:
`Uncaught TypeError: elements is undefined`

![изображение](https://github.com/richrobber2/canvas-zoom/assets/132840938/f82479ae-0389-4846-ba2c-0d3741b54f79)
In this place:
https://github.com/richrobber2/canvas-zoom/blob/ae44f7fba3fcc8d118f8905a0888585dd2728a61/javascript/canvas-zoom.js#L71
Because `elements` are not passed to `getTabId()` here:
https://github.com/richrobber2/canvas-zoom/blob/ae44f7fba3fcc8d118f8905a0888585dd2728a61/javascript/canvas-zoom.js#L462
